### PR TITLE
feat: support HTML content for invoice loading

### DIFF
--- a/src/sales/dto/create-sale-dto.ts
+++ b/src/sales/dto/create-sale-dto.ts
@@ -1,3 +1,4 @@
 export class CreateSaleDto {
-  url: string;
+  url?: string;
+  html?: string;
 }

--- a/src/sales/entity/sale.entity.ts
+++ b/src/sales/entity/sale.entity.ts
@@ -29,8 +29,8 @@ export class Sale {
   @OneToMany(() => PriceHistory, (priceHistory) => priceHistory.sale)
   priceHistory: PriceHistory[];
 
-  @Column({ name: 'invoice_url' })
-  invoiceUrl: string;
+  @Column({ name: 'invoice_url', nullable: true })
+  invoiceUrl?: string;
 
   static fromJSON(data: any): Sale {
     return {

--- a/src/sales/invoice.service.spec.ts
+++ b/src/sales/invoice.service.spec.ts
@@ -72,7 +72,7 @@ describe('InvoiceService', () => {
 
     httpServiceMock.post.mockImplementationOnce(() => of(response));
 
-    const data = await service.fetchData(url);
+    const data = await service.fetchData({ url });
 
     expect(data).toEqual(InvoiceData.fromJSON(PRODUCT_DB_DATA.result));
   });

--- a/src/sales/invoice.service.ts
+++ b/src/sales/invoice.service.ts
@@ -16,7 +16,10 @@ export class InvoiceService {
 
   constructor(private readonly httpService: HttpService) {}
 
-  async fetchData(input: { url?: string; html?: string }): Promise<InvoiceData> {
+  async fetchData(input: {
+    url?: string;
+    html?: string;
+  }): Promise<InvoiceData> {
     this.logger.log(
       `Fetching invoice data from server: ${process.env.INVOICE_URL}`,
     );

--- a/src/sales/invoice.service.ts
+++ b/src/sales/invoice.service.ts
@@ -16,15 +16,13 @@ export class InvoiceService {
 
   constructor(private readonly httpService: HttpService) {}
 
-  async fetchData(url: string): Promise<InvoiceData> {
+  async fetchData(input: { url?: string; html?: string }): Promise<InvoiceData> {
     this.logger.log(
       `Fetching invoice data from server: ${process.env.INVOICE_URL}`,
     );
     try {
       const { data } = await firstValueFrom(
-        this.httpService.post(process.env.INVOICE_URL, {
-          url: url,
-        }),
+        this.httpService.post(process.env.INVOICE_URL, input),
       );
       return InvoiceData.fromJSON(data.result);
     } catch (error) {

--- a/src/sales/sales.controller.spec.ts
+++ b/src/sales/sales.controller.spec.ts
@@ -69,6 +69,6 @@ describe('SalesController', () => {
     const result = await controller.create(saleToBeCreated);
 
     expect(result).toHaveProperty('id', sale.id);
-    expect(serviceMock.create).toHaveBeenCalledWith(saleToBeCreated.url);
+    expect(serviceMock.create).toHaveBeenCalledWith(saleToBeCreated);
   });
 });

--- a/src/sales/sales.controller.ts
+++ b/src/sales/sales.controller.ts
@@ -33,6 +33,6 @@ export class SalesController {
 
   @Post()
   async create(@Body() createSaleDto: CreateSaleDto): Promise<string> {
-    return this.salesService.create(createSaleDto.url);
+    return this.salesService.create(createSaleDto);
   }
 }

--- a/src/sales/sales.service.spec.ts
+++ b/src/sales/sales.service.spec.ts
@@ -251,7 +251,9 @@ describe('SalesService', () => {
     invoiceServiceMock.fetchData.mockReturnValue(Promise.resolve(invoiceData));
     repositoryMock.findOne.mockReturnValueOnce({ id: 'SALE_ID' });
 
-    await expect(service.create({ url: 'url' })).rejects.toThrow('Sale already exists');
+    await expect(service.create({ url: 'url' })).rejects.toThrow(
+      'Sale already exists',
+    );
   });
 
   it('should throw BadRequestException when neither url nor html is provided', async () => {

--- a/src/sales/sales.service.spec.ts
+++ b/src/sales/sales.service.spec.ts
@@ -183,7 +183,7 @@ describe('SalesService', () => {
       Promise.resolve({ ...invoiceData.store }),
     );
 
-    const saleId = await service.create(url);
+    const saleId = await service.create({ url });
 
     expect(saleId).toEqual(invoiceData.sale.id);
     expect(repositoryMock.save).toHaveBeenCalledWith({
@@ -195,6 +195,48 @@ describe('SalesService', () => {
       invoiceData.products.length,
     );
     expect(storeServiceMock.create).toHaveBeenCalledWith(invoiceData.store);
+  });
+
+  it('should create a sale from html content with null invoiceUrl', async () => {
+    const html = '<html><body>invoice html content</body></html>';
+    const invoiceData: InvoiceData = {
+      store: {
+        id: 'STORE_ID',
+        name: 'Test Store',
+        address: 'Test Address',
+      },
+      sale: {
+        id: 'SALE_ID',
+        total: 58.22,
+        date: '2026-04-18',
+      },
+      products: [
+        {
+          name: 'PIPOCA DOC JUPOCA40G',
+          value: 1.89,
+          code: '92765',
+          amount: 1,
+          type: 'Un',
+          date: '2026-04-18',
+        },
+      ],
+    };
+
+    invoiceServiceMock.fetchData.mockReturnValue(Promise.resolve(invoiceData));
+    repositoryMock.findOne.mockReturnValueOnce(null);
+    storeServiceMock.create.mockReturnValue(
+      Promise.resolve({ ...invoiceData.store }),
+    );
+
+    const saleId = await service.create({ html });
+
+    expect(saleId).toEqual(invoiceData.sale.id);
+    expect(invoiceServiceMock.fetchData).toHaveBeenCalledWith({ html });
+    expect(repositoryMock.save).toHaveBeenCalledWith({
+      ...invoiceData.sale,
+      invoiceUrl: null,
+      store: invoiceData.store,
+    });
   });
 
   it('it should throw an error when a sale already exists', async () => {
@@ -209,19 +251,16 @@ describe('SalesService', () => {
     invoiceServiceMock.fetchData.mockReturnValue(Promise.resolve(invoiceData));
     repositoryMock.findOne.mockReturnValueOnce({ id: 'SALE_ID' });
 
-    await expect(service.create('url')).rejects.toThrow('Sale already exists');
+    await expect(service.create({ url: 'url' })).rejects.toThrow('Sale already exists');
   });
 
-  it('should throw BadRequestException for invalid URL', async () => {
-    // Test with null URL
-    await expect(service.create(null)).rejects.toThrow('Invalid URL provided');
+  it('should throw BadRequestException when neither url nor html is provided', async () => {
+    await expect(service.create({})).rejects.toThrow(
+      'You must provide either a URL or HTML content',
+    );
 
-    // Test with empty string URL
-    await expect(service.create('')).rejects.toThrow('Invalid URL provided');
-
-    // Test with non-string URL
-    await expect(service.create(123 as any)).rejects.toThrow(
-      'Invalid URL provided',
+    await expect(service.create({ url: '', html: '' })).rejects.toThrow(
+      'You must provide either a URL or HTML content',
     );
   });
 });

--- a/src/sales/sales.service.ts
+++ b/src/sales/sales.service.ts
@@ -68,14 +68,13 @@ export class SalesService {
     return [data.map((sale) => Sale.fromJSON(sale)), total];
   }
 
-  async create(url: string): Promise<string> {
-    // Validate URL
-    if (!url || typeof url !== 'string') {
-      throw new BadRequestException('Invalid URL provided');
+  async create(input: { url?: string; html?: string }): Promise<string> {
+    if (!input.url && !input.html) {
+      throw new BadRequestException('You must provide either a URL or HTML content');
     }
 
     try {
-      const invoiceData = await this.invoiceService.fetchData(url);
+      const invoiceData = await this.invoiceService.fetchData(input);
 
       this.logger.assign({
         _invoice: {
@@ -100,7 +99,7 @@ export class SalesService {
       await this.saleRepository.save({
         ...invoiceData.sale,
         store: store,
-        invoiceUrl: url,
+        invoiceUrl: input.url || null,
       });
 
       // create products

--- a/src/sales/sales.service.ts
+++ b/src/sales/sales.service.ts
@@ -70,7 +70,9 @@ export class SalesService {
 
   async create(input: { url?: string; html?: string }): Promise<string> {
     if (!input.url && !input.html) {
-      throw new BadRequestException('You must provide either a URL or HTML content');
+      throw new BadRequestException(
+        'You must provide either a URL or HTML content',
+      );
     }
 
     try {


### PR DESCRIPTION
Allow sales creation from HTML content as an alternative to URL, for cases where QR codes redirect to reCAPTCHA-protected pages.

- CreateSaleDto accepts optional url or html
- InvoiceService.fetchData() forwards { url } or { html } to microservice
- SalesService.create() validates that at least one input is provided
- Sale entity invoiceUrl is now nullable (null when created from HTML)
- Updated tests to cover the HTML input path