### PR TITLE
chore(dev): seed local Postgres with schema + dummy data via compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ Temporary Items
 # Local
 .env
 .env-supabase
+*.bak
 dist
 .webpack
 .serverless/**/*.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ npm run lint            # ESLint with auto-fix
 npm run format          # Prettier format
 
 # Database (local dev)
-docker compose up -d db  # Start Postgres 12 on port 5432
+docker compose up -d db       # Start Postgres 12 on port 5432
+docker compose down -v        # Stop and wipe data volume (forces re-seed on next up)
 ```
 
 ## Environment Variables
@@ -47,6 +48,20 @@ The app requires these env vars (use a `.env` file via `@nestjs/config`):
 | `NODE_ENV` | Set to `development` to disable authentication guard |
 
 Local Postgres defaults (from `docker-compose.yml`): user/password/db all `postgres`, port `5432`.
+
+## Local Development Setup
+
+For local development with an isolated, empty database (so the Flutter app or tests don't hit production data):
+
+1. **`.env`** — copy from `.env-local` and append `NODE_ENV=development` (skips `SupabaseGuard`). `INVOICE_URL` can stay pointing at the prod scraper.
+2. **`docker compose up -d db`** — first start seeds the database by running `/docker-entrypoint-initdb.d/*.sql` in alphabetical order:
+   - `schema.sql` (mounted as `01-schema.sql`) creates the four tables: `stores`, `products`, `sales`, `price_history`.
+   - `dummy_data.sql` (mounted as `02-dummy-data.sql`) inserts a small fixture: 3 stores, 5 products, 3 sales, 8 price-history rows. Edit this file to change the seed.
+3. **`npm run start:dev`** — Nest listens on `0.0.0.0:3000` (LAN-accessible by default for physical-device testing).
+
+**Re-seeding rule:** init scripts only run when the data volume is empty. To pick up changes to `schema.sql` or `dummy_data.sql`, run `docker compose down -v && docker compose up -d db` (the `-v` wipes the volume).
+
+**Schema source of truth:** `schema.sql` is hand-maintained (no TypeORM migrations, no `synchronize`). If you add or change an `@Entity()`, mirror the change in `schema.sql`.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,7 @@ services:
       - '5432:5432'
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./dummy_data.sql:/docker-entrypoint-initdb.d/02-dummy-data.sql:ro
 volumes:
   pgdata: {}

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,0 +1,32 @@
+-- Dummy seed data for local dev. Loaded after schema.sql by docker-entrypoint-initdb.d.
+
+INSERT INTO public.stores (id, name, address) VALUES
+  ('11111111000111', 'Supermercado Central', 'Av. Brasil, 1000 - Centro'),
+  ('22222222000122', 'Mercadinho da Esquina', 'Rua das Flores, 250 - Jardim'),
+  ('33333333000133', 'Atacado Bom Preço', 'Rodovia BR-101, km 42');
+
+INSERT INTO public.sales (id, date, total, store_id, invoice_url) VALUES
+  ('SALE-0001', '2026-05-10 14:32:00', 87.50,  '11111111000111', 'https://example.invoice/0001'),
+  ('SALE-0002', '2026-05-12 09:15:00', 42.10,  '22222222000122', 'https://example.invoice/0002'),
+  ('SALE-0003', '2026-05-14 18:47:00', 156.30, '33333333000133', 'https://example.invoice/0003');
+
+-- products: explicit ids so we can reference them in price_history
+INSERT INTO public.products (id, name, code, amount, type, is_ean) OVERRIDING SYSTEM VALUE VALUES
+  (1, 'Arroz Branco 5kg',        '7891234567890', 1,   'UN', true),
+  (2, 'Feijão Carioca 1kg',      '7899876543210', 2,   'UN', true),
+  (3, 'Leite Integral 1L',       '7891111222233', 6,   'UN', true),
+  (4, 'Banana Prata',            NULL,            1.5, 'KG', false),
+  (5, 'Detergente Líquido 500ml','7894444555566', 3,   'UN', true);
+
+-- realign the identity sequence so future inserts don't collide
+SELECT setval(pg_get_serial_sequence('public.products','id'), (SELECT MAX(id) FROM public.products));
+
+INSERT INTO public.price_history (product_id, sale_id, value, date) VALUES
+  (1, 'SALE-0001', 28.90, '2026-05-10'),
+  (2, 'SALE-0001', 9.80,  '2026-05-10'),
+  (3, 'SALE-0001', 4.95,  '2026-05-10'),
+  (4, 'SALE-0002', 6.50,  '2026-05-12'),
+  (3, 'SALE-0002', 5.10,  '2026-05-12'),
+  (1, 'SALE-0003', 27.50, '2026-05-14'),
+  (5, 'SALE-0003', 7.20,  '2026-05-14'),
+  (2, 'SALE-0003', 10.40, '2026-05-14');

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,41 @@
+-- Reordered from Supabase schema visualizer export: stores → products → sales → price_history
+CREATE TABLE public.stores (
+  id character varying NOT NULL,
+  name character varying,
+  address character varying,
+  CONSTRAINT stores_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public.products (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  name character varying NOT NULL,
+  code character varying,
+  amount numeric,
+  type character varying,
+  is_ean boolean,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT products_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public.sales (
+  id character varying NOT NULL,
+  date timestamp without time zone NOT NULL,
+  total numeric,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  store_id character varying,
+  invoice_url text,
+  CONSTRAINT sales_pkey PRIMARY KEY (id),
+  CONSTRAINT sales_store_id_fkey FOREIGN KEY (store_id) REFERENCES public.stores(id)
+);
+
+CREATE TABLE public.price_history (
+  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+  product_id bigint NOT NULL,
+  sale_id character varying,
+  value numeric NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  date date NOT NULL,
+  CONSTRAINT price_history_pkey PRIMARY KEY (id),
+  CONSTRAINT price_history_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.products(id),
+  CONSTRAINT price_history_sale_id_fkey FOREIGN KEY (sale_id) REFERENCES public.sales(id)
+);


### PR DESCRIPTION
Mount schema.sql and dummy_data.sql into /docker-entrypoint-initdb.d/ so a fresh container automatically provisions all tables and a small fixture (3 stores, 5 products, 3 sales, 8 price-history rows). Enables running the Flutter app and other clients against an isolated local backend without touching production. Documented the flow in CLAUDE.md and ignored *.bak so the prod env backup never gets committed.